### PR TITLE
Change snake_case to camelCase namings

### DIFF
--- a/src/main/java/example/medCashFlow/controller/EmployeeController.java
+++ b/src/main/java/example/medCashFlow/controller/EmployeeController.java
@@ -34,8 +34,8 @@ public class EmployeeController {
 
         EmployeeResponseDTO employeeResponseDTO = new EmployeeResponseDTO(
                 employee.getId(),
-                employee.getFirst_name(),
-                employee.getLast_name(),
+                employee.getFirstName(),
+                employee.getLastName(),
                 employee.getCpf(),
                 employee.getEmail(),
                 employee.getRole().getName(),

--- a/src/main/java/example/medCashFlow/dto/employee/ManagerRegisterDTO.java
+++ b/src/main/java/example/medCashFlow/dto/employee/ManagerRegisterDTO.java
@@ -1,4 +1,4 @@
 package example.medCashFlow.dto.employee;
 
-public record ManagerRegisterDTO(String first_name, String last_name, String cpf, String email, String password) {
+public record ManagerRegisterDTO(String firstName, String lastName, String cpf, String email, String password) {
 }

--- a/src/main/java/example/medCashFlow/model/Employee.java
+++ b/src/main/java/example/medCashFlow/model/Employee.java
@@ -25,11 +25,11 @@ public class Employee implements UserDetails {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
-    private String first_name;
+    @Column(name = "firstName", nullable = false)
+    private String firstName;
 
-    @Column(nullable = false)
-    private String last_name;
+    @Column(name = "lastName",nullable = false)
+    private String lastName;
 
     @Column(nullable = false, unique = true)
     private String cpf;
@@ -52,8 +52,8 @@ public class Employee implements UserDetails {
     private boolean isActive = true;
 
     public Employee(ManagerRegisterDTO data, String encryptedPassword, Role role, Clinic clinic) {
-        this.first_name = data.first_name();
-        this.last_name = data.last_name();
+        this.firstName = data.firstName();
+        this.lastName = data.lastName();
         this.cpf = data.cpf();
         this.email = data.email();
         this.password = encryptedPassword;
@@ -62,8 +62,8 @@ public class Employee implements UserDetails {
     }
 
     public Employee(EmployeeRegisterDTO data) {
-        this.first_name = data.firstName();
-        this.last_name = data.lastName();
+        this.firstName = data.firstName();
+        this.lastName = data.lastName();
         this.cpf = data.cpf();
         this.email = data.email();
     }

--- a/src/main/java/example/medCashFlow/services/EmployeeService.java
+++ b/src/main/java/example/medCashFlow/services/EmployeeService.java
@@ -32,8 +32,8 @@ public class EmployeeService {
         return repository.findAllByClinicIdOrderById(clinicId).stream()
                 .map(employee -> new EmployeeResponseDTO(
                         employee.getId(),
-                        employee.getFirst_name(),
-                        employee.getLast_name(),
+                        employee.getFirstName(),
+                        employee.getLastName(),
                         employee.getCpf(),
                         employee.getEmail(),
                         employee.getRole().getName(),
@@ -70,8 +70,8 @@ public class EmployeeService {
 
         return new EmployeeResponseDTO(
                 employee.getId(),
-                employee.getFirst_name(),
-                employee.getLast_name(),
+                employee.getFirstName(),
+                employee.getLastName(),
                 employee.getCpf(),
                 employee.getEmail(),
                 employee.getRole().getName(),
@@ -92,8 +92,8 @@ public class EmployeeService {
             throw new InvalidEmployeeException("manager.cpf");
         }
 
-        existingEmployee.setFirst_name(employee.getFirst_name());
-        existingEmployee.setLast_name(employee.getLast_name());
+        existingEmployee.setFirstName(employee.getFirstName());
+        existingEmployee.setLastName(employee.getLastName());
         existingEmployee.setEmail(employee.getEmail());
         existingEmployee.setCpf(employee.getCpf());
         existingEmployee.setPassword(employee.getPassword());
@@ -103,8 +103,8 @@ public class EmployeeService {
 
         return new EmployeeResponseDTO(
                 existingEmployee.getId(),
-                existingEmployee.getFirst_name(),
-                existingEmployee.getLast_name(),
+                existingEmployee.getFirstName(),
+                existingEmployee.getLastName(),
                 existingEmployee.getCpf(),
                 existingEmployee.getEmail(),
                 existingEmployee.getRole().getName(),

--- a/src/test/java/example/medCashFlow/AccountPlanningControllerTests.java
+++ b/src/test/java/example/medCashFlow/AccountPlanningControllerTests.java
@@ -20,13 +20,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class AccountPlanningControllerTests extends MedCashFlowApplicationTests {
 
     @Test
-    void whenAnonymousGettingAccountPlanningById_thenForbidden() throws Exception {
+    void whenAnonymousGettingAccountPlanningByIdThenForbidden() throws Exception {
         mockMvc.perform(get("/account-plannings/1"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeGettingAccountPlanningById_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeGettingAccountPlanningByIdThenSucceeds() throws Exception {
         mockMvc.perform(get("/account-plannings/1")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isOk())
@@ -38,41 +38,41 @@ public class AccountPlanningControllerTests extends MedCashFlowApplicationTests 
     }
 
     @Test
-    void whenAllowedEmployeeGettingNonExistentAccountPlanningById_thenNotFound() throws Exception {
+    void whenAllowedEmployeeGettingNonExistentAccountPlanningByIdThenNotFound() throws Exception {
         mockMvc.perform(get("/account-plannings/2")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNotFound());
     }
 
     @Test
-    void whenAdminGettingAccountPlanningById_thenForbidden() throws Exception {
+    void whenAdminGettingAccountPlanningByIdThenForbidden() throws Exception {
         mockMvc.perform(get("/account-plannings/1")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAnonymousListingAccountPlannings_thenForbidden() throws Exception {
+    void whenAnonymousListingAccountPlanningsThenForbidden() throws Exception {
         mockMvc.perform(get("/account-plannings/list"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeListingAccountPlannings_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeListingAccountPlanningsThenSucceeds() throws Exception {
         mockMvc.perform(get("/account-plannings/list")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isOk());
     }
 
     @Test
-    void whenAdminListingAccountPlannings_thenForbidden() throws Exception {
+    void whenAdminListingAccountPlanningsThenForbidden() throws Exception {
         mockMvc.perform(get("/account-plannings/list")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAnonymousCreateAccountPlanning_thenForbidden() throws Exception {
+    void whenAnonymousCreateAccountPlanningThenForbidden() throws Exception {
         AccountPlanningRegisterDTO planningDTO = new AccountPlanningRegisterDTO(
                 "Test Planning",
                 "Test Description",
@@ -87,7 +87,7 @@ public class AccountPlanningControllerTests extends MedCashFlowApplicationTests 
     }
 
     @Test
-    void whenAllowedEmployeeCreateAccountPlanning_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeCreateAccountPlanningThenSucceeds() throws Exception {
         AccountPlanningRegisterDTO planningDTO = new AccountPlanningRegisterDTO(
                 "Test Planning 2",
                 "Test Description 2",
@@ -106,7 +106,7 @@ public class AccountPlanningControllerTests extends MedCashFlowApplicationTests 
     }
 
     @Test
-    void whenAdminCreateAccountPlanning_thenForbidden() throws Exception {
+    void whenAdminCreateAccountPlanningThenForbidden() throws Exception {
         AccountPlanningRegisterDTO planningDTO = new AccountPlanningRegisterDTO(
                 "Test Planning",
                 "Test Description",
@@ -122,7 +122,7 @@ public class AccountPlanningControllerTests extends MedCashFlowApplicationTests 
     }
 
     @Test
-    void whenAnonymousUpdateAccountPlanning_thenForbidden() throws Exception {
+    void whenAnonymousUpdateAccountPlanningThenForbidden() throws Exception {
         AccountPlanningRegisterDTO planningDTO = new AccountPlanningRegisterDTO(
                 "Updated Planning",
                 "Updated Description",
@@ -137,7 +137,7 @@ public class AccountPlanningControllerTests extends MedCashFlowApplicationTests 
     }
 
     @Test
-    void whenAllowedEmployeeUpdateAccountPlanning_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeUpdateAccountPlanningThenSucceeds() throws Exception {
         AccountPlanningRegisterDTO createDTO = new AccountPlanningRegisterDTO(
                 "Original Planning",
                 "Original Description",
@@ -173,7 +173,7 @@ public class AccountPlanningControllerTests extends MedCashFlowApplicationTests 
     }
 
     @Test
-    void whenAllowedEmployeeUpdateNonExistentAccountPlanning_thenNotFound() throws Exception {
+    void whenAllowedEmployeeUpdateNonExistentAccountPlanningThenNotFound() throws Exception {
         AccountPlanningRegisterDTO planningDTO = new AccountPlanningRegisterDTO(
                 "Updated Planning",
                 "Updated Description",
@@ -189,7 +189,7 @@ public class AccountPlanningControllerTests extends MedCashFlowApplicationTests 
     }
 
     @Test
-    void whenAdminUpdateAccountPlanning_thenForbidden() throws Exception {
+    void whenAdminUpdateAccountPlanningThenForbidden() throws Exception {
         AccountPlanningRegisterDTO planningDTO = new AccountPlanningRegisterDTO(
                 "Updated Planning",
                 "Updated Description",
@@ -205,13 +205,13 @@ public class AccountPlanningControllerTests extends MedCashFlowApplicationTests 
     }
 
     @Test
-    void whenAnonymousDeleteAccountPlanning_thenForbidden() throws Exception {
+    void whenAnonymousDeleteAccountPlanningThenForbidden() throws Exception {
         mockMvc.perform(delete("/account-plannings/delete/1"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeDeleteAccountPlanning_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeDeleteAccountPlanningThenSucceeds() throws Exception {
         AccountPlanningRegisterDTO createDTO = new AccountPlanningRegisterDTO(
                 "To Delete",
                 "Will be deleted",
@@ -235,14 +235,14 @@ public class AccountPlanningControllerTests extends MedCashFlowApplicationTests 
     }
 
     @Test
-    void whenAllowedEmployeeDeleteNonExistentAccountPlanning_thenNotFound() throws Exception {
+    void whenAllowedEmployeeDeleteNonExistentAccountPlanningThenNotFound() throws Exception {
         mockMvc.perform(delete("/account-plannings/delete/999999")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNotFound());
     }
 
     @Test
-    void whenAdminDeleteAccountPlanning_thenForbidden() throws Exception {
+    void whenAdminDeleteAccountPlanningThenForbidden() throws Exception {
         mockMvc.perform(delete("/account-plannings/delete/1")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());

--- a/src/test/java/example/medCashFlow/AuthenticationControllerTests.java
+++ b/src/test/java/example/medCashFlow/AuthenticationControllerTests.java
@@ -23,13 +23,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class AuthenticationControllerTests extends MedCashFlowApplicationTests {
 
     @Test
-    void whenAnonymousGetBillById_thenForbidden() throws Exception {
+    void whenAnonymousGetBillByIdThenForbidden() throws Exception {
         mockMvc.perform(get("/involveds/1"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeGetInvolvedById_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeGetInvolvedByIdThenSucceeds() throws Exception {
         mockMvc.perform(get("/involveds/1")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isOk())
@@ -42,21 +42,21 @@ class AuthenticationControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAllowedEmployeeGetNonExistentInvolvedById_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeGetNonExistentInvolvedByIdThenSucceeds() throws Exception {
         mockMvc.perform(get("/involveds/999")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNotFound());
     }
 
     @Test
-    void whenAdminGetInvolvedById_thenForbidden() throws Exception {
+    void whenAdminGetInvolvedByIdThenForbidden() throws Exception {
         mockMvc.perform(get("/involveds/1")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenRegisteringNonExistingClinic_thenSucceeds() throws Exception {
+    void whenRegisteringNonExistingClinicThenSucceeds() throws Exception {
         RegisterDTO registerDto = new RegisterDTO(
                 new ClinicRegisterDTO("Clinic 2", "12345678901236", "1234567892"),
                 new ManagerRegisterDTO("John", "Doe", "34567890123", "clinicateste@manager.com", "manager")
@@ -76,7 +76,7 @@ class AuthenticationControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenRegisteringExistingClinic_thenConflict() throws Exception {
+    void whenRegisteringExistingClinicThenConflict() throws Exception {
         RegisterDTO registerDTO = new RegisterDTO(
                 new ClinicRegisterDTO("Clinic1", "12345678901234", "1234567890"),
                 new ManagerRegisterDTO("João", "Lucas", "12345678903", "manager3@manager.com", "manager3")
@@ -88,7 +88,7 @@ class AuthenticationControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenRegisteringExistingEmployee_thenConflict() throws Exception {
+    void whenRegisteringExistingEmployeeThenConflict() throws Exception {
         RegisterDTO registerDTO = new RegisterDTO(
                 new ClinicRegisterDTO("Clinic3", "12345678901236", "1234567892"),
                 new ManagerRegisterDTO("Pedro", "Arthur", "12345678901", "manager@manager.com", "manager")
@@ -100,7 +100,7 @@ class AuthenticationControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenLoginExistingEmployee_thenSucceeds() throws Exception {
+    void whenLoginExistingEmployeeThenSucceeds() throws Exception {
         AuthenticationDTO authenticationDTO = new AuthenticationDTO(
                 "manager@manager.com",
                 "manager"
@@ -116,7 +116,7 @@ class AuthenticationControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenLoggingInactiveClinic_thenNotFound() throws Exception {
+    void whenLoggingInactiveClinicThenNotFound() throws Exception {
         AuthenticationDTO data = new AuthenticationDTO(
                 "manager@manager.com.in",
                 "manager"
@@ -130,7 +130,7 @@ class AuthenticationControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenLoginInvalidEmailEmployee_thenBadCredentials() throws Exception {
+    void whenLoginInvalidEmailEmployeeThenBadCredentials() throws Exception {
         AuthenticationDTO authenticationDTO = new AuthenticationDTO(
                 "manager@manager.com.br",
                 "manager"
@@ -142,7 +142,7 @@ class AuthenticationControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenLoginExistingInvalidPasswordEmployee_thenBadCredentials() throws Exception {
+    void whenLoginExistingInvalidPasswordEmployeeThenBadCredentials() throws Exception {
         AuthenticationDTO authenticationDTO = new AuthenticationDTO(
                 "manager@manager.com",
                 "manager2"
@@ -154,7 +154,7 @@ class AuthenticationControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenLoginExistingAdmin_thenSucceeds() throws Exception {
+    void whenLoginExistingAdminThenSucceeds() throws Exception {
         AuthenticationDTO authenticationDTO = new AuthenticationDTO(
                 "admin@admin.com",
                 "admin123"
@@ -170,7 +170,7 @@ class AuthenticationControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenLoginInvalidEmailAdmin_thenBadCredentials() throws Exception {
+    void whenLoginInvalidEmailAdminThenBadCredentials() throws Exception {
         AuthenticationDTO authenticationDTO = new AuthenticationDTO(
                 "admin@admin.com.br",
                 "admin123"
@@ -182,7 +182,7 @@ class AuthenticationControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenLoginInvalidPasswordAdmin_thenBadCredentials() throws Exception {
+    void whenLoginInvalidPasswordAdminThenBadCredentials() throws Exception {
         AuthenticationDTO authenticationDTO = new AuthenticationDTO(
                 "admin@admin.com",
                 "admin"

--- a/src/test/java/example/medCashFlow/BillControllerTests.java
+++ b/src/test/java/example/medCashFlow/BillControllerTests.java
@@ -12,27 +12,27 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class BillControllerTests extends MedCashFlowApplicationTests {
 
     @Test
-    void whenAnonymousListingBills_thenForbidden() throws Exception {
+    void whenAnonymousListingBillsThenForbidden() throws Exception {
         mockMvc.perform(get("/bills/list"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeListingBills_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeListingBillsThenSucceeds() throws Exception {
         mockMvc.perform(get("/bills/list")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isOk());
     }
 
     @Test
-    void whenAdminListingBills_thenForbidden() throws Exception {
+    void whenAdminListingBillsThenForbidden() throws Exception {
         mockMvc.perform(get("/bills/list")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAnonymousCreateBill_thenForbidden() throws Exception {
+    void whenAnonymousCreateBillThenForbidden() throws Exception {
         BillRegisterDTO billDTO = new BillRegisterDTO(
                 "Test Bill",
                 100.00,
@@ -51,7 +51,7 @@ public class BillControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAllowedEmployeeCreateBill_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeCreateBillThenSucceeds() throws Exception {
         BillRegisterDTO billDTO = new BillRegisterDTO(
                 "Test Bill",
                 100.00,
@@ -71,7 +71,7 @@ public class BillControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAdminCreateBill_thenForbidden() throws Exception {
+    void whenAdminCreateBillThenForbidden() throws Exception {
         BillRegisterDTO billDTO = new BillRegisterDTO(
                 "Test Bill",
                 100.00,
@@ -91,7 +91,7 @@ public class BillControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAnonymousUpdateBill_thenForbidden() throws Exception {
+    void whenAnonymousUpdateBillThenForbidden() throws Exception {
         BillRegisterDTO billDTO = new BillRegisterDTO(
                 "Updated Bill",
                 200.00,
@@ -110,7 +110,7 @@ public class BillControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAllowedEmployeeUpdateBill_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeUpdateBillThenSucceeds() throws Exception {
         BillRegisterDTO updateDTO = new BillRegisterDTO(
                 "Updated Bill",
                 200.00,
@@ -130,27 +130,27 @@ public class BillControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAnonymousDeleteBill_thenForbidden() throws Exception {
+    void whenAnonymousDeleteBillThenForbidden() throws Exception {
         mockMvc.perform(delete("/bills/delete/1"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeDeleteBill_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeDeleteBillThenSucceeds() throws Exception {
         mockMvc.perform(delete("/bills/delete/1")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNoContent());
     }
 
     @Test
-    void whenAdminDeleteBill_thenForbidden() throws Exception {
+    void whenAdminDeleteBillThenForbidden() throws Exception {
         mockMvc.perform(delete("/bills/delete/1")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeUpdateNonExistentBill_thenNotFound() throws Exception {
+    void whenAllowedEmployeeUpdateNonExistentBillThenNotFound() throws Exception {
         BillRegisterDTO billDTO = new BillRegisterDTO(
                 "Non-existent Bill",
                 100.00,
@@ -170,7 +170,7 @@ public class BillControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAllowedEmployeeDeleteNonExistentBill_thenNotFound() throws Exception {
+    void whenAllowedEmployeeDeleteNonExistentBillThenNotFound() throws Exception {
         mockMvc.perform(delete("/bills/delete/999999")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNotFound());

--- a/src/test/java/example/medCashFlow/ClinicControllerTests.java
+++ b/src/test/java/example/medCashFlow/ClinicControllerTests.java
@@ -28,13 +28,13 @@ public class ClinicControllerTests extends MedCashFlowApplicationTests {
     private MockMvc mockMvc;
 
     @Test
-    void whenAnonymousAccessClinics_thenUnauthorized() throws Exception {
+    void whenAnonymousAccessClinicsThenUnauthorized() throws Exception {
         mockMvc.perform(get("/clinics"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAdminAccessClinics_thenSucceeds() throws Exception {
+    void whenAdminAccessClinicsThenSucceeds() throws Exception {
         mockMvc.perform(get("/clinics/list")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isOk())
@@ -48,14 +48,14 @@ public class ClinicControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenEmployeeAccessClinics_thenForbidden() throws Exception {
+    void whenEmployeeAccessClinicsThenForbidden() throws Exception {
         mockMvc.perform(get("/clinics/list")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAnonymousDeleteClinics_thenUnauthorized() throws Exception {
+    void whenAnonymousDeleteClinicsThenUnauthorized() throws Exception {
         List<ClinicResponseDTO> clinics = clinicService.getAllClinics();
 
         UUID id = clinics.get(0).id();
@@ -64,7 +64,7 @@ public class ClinicControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAdminDeleteClinics_thenSucceeds() throws Exception {
+    void whenAdminDeleteClinicsThenSucceeds() throws Exception {
         List<ClinicResponseDTO> clinics = clinicService.getAllClinics();
         UUID id = clinics.get(0).id();
 
@@ -84,7 +84,7 @@ public class ClinicControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenEmployeeDeleteClinics_thenForbidden() throws Exception {
+    void whenEmployeeDeleteClinicsThenForbidden() throws Exception {
         List<ClinicResponseDTO> clinics = clinicService.getAllClinics();
 
         UUID id = clinics.get(0).id();
@@ -95,7 +95,7 @@ public class ClinicControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAnonymousActivateClinics_thenUnauthorized() throws Exception {
+    void whenAnonymousActivateClinicsThenUnauthorized() throws Exception {
         List<ClinicResponseDTO> clinics = clinicService.getAllClinics();
 
         UUID id = clinics.get(0).id();
@@ -104,7 +104,7 @@ public class ClinicControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAdminActivateClinics_thenSucceeds() throws Exception {
+    void whenAdminActivateClinicsThenSucceeds() throws Exception {
         List<ClinicResponseDTO> clinics = clinicService.getAllClinics();
         UUID id = clinics.get(1).id();
 
@@ -119,7 +119,7 @@ public class ClinicControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenEmployeeActivateClinics_thenForbidden() throws Exception {
+    void whenEmployeeActivateClinicsThenForbidden() throws Exception {
         List<ClinicResponseDTO> clinics = clinicService.getAllClinics();
 
         UUID id = clinics.get(0).id();

--- a/src/test/java/example/medCashFlow/EmployeeControllerTests.java
+++ b/src/test/java/example/medCashFlow/EmployeeControllerTests.java
@@ -254,8 +254,8 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
         Employee deletedEmployee = employeeService.getEmployeeByEmail("financial@financial.com");
         assertFalse(deletedEmployee.isActive());
         assertNotNull(deletedEmployee.getId());
-        assertEquals("João", deletedEmployee.getFirst_name());
-        assertEquals("Pé de Feijão", deletedEmployee.getLast_name());
+        assertEquals("João", deletedEmployee.getFirstName());
+        assertEquals("Pé de Feijão", deletedEmployee.getLastName());
         assertEquals("financial@financial.com", deletedEmployee.getEmail());
     }
 
@@ -310,8 +310,8 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
         Employee activatedEmployee = employeeService.getEmployeeByEmail("financial2@financial.com");
         assertTrue(activatedEmployee.isActive());
         assertNotNull(activatedEmployee.getId());
-        assertEquals("Francisco", activatedEmployee.getFirst_name());
-        assertEquals("Xavier", activatedEmployee.getLast_name());
+        assertEquals("Francisco", activatedEmployee.getFirstName());
+        assertEquals("Xavier", activatedEmployee.getLastName());
         assertEquals("financial2@financial.com", activatedEmployee.getEmail());
     }
 

--- a/src/test/java/example/medCashFlow/EmployeeControllerTests.java
+++ b/src/test/java/example/medCashFlow/EmployeeControllerTests.java
@@ -20,13 +20,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class EmployeeControllerTests extends MedCashFlowApplicationTests {
 
     @Test
-    void whenAnonymousGettingEmployeeById_thenForbidden() throws Exception {
+    void whenAnonymousGettingEmployeeByIdThenForbidden() throws Exception {
         mockMvc.perform(get("/employees/1"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeGettingEmployeeById_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeGettingEmployeeByIdThenSucceeds() throws Exception {
         mockMvc.perform(get("/employees/1")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isOk())
@@ -40,27 +40,27 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAllowedEmployeeGettingNonExistentEmployeeById_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeGettingNonExistentEmployeeByIdThenSucceeds() throws Exception {
         mockMvc.perform(get("/employees/999")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNotFound());
     }
 
     @Test
-    void whenNotAllowedEmployeeGettingEmployeeById_thenForbidden() throws Exception {
+    void whenNotAllowedEmployeeGettingEmployeeByIdThenForbidden() throws Exception {
         mockMvc.perform(get("/employees/1")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAnonymousListingEmployees_thenForbidden() throws Exception {
+    void whenAnonymousListingEmployeesThenForbidden() throws Exception {
         mockMvc.perform(get("/employees/list"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeListingEmployees_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeListingEmployeesThenSucceeds() throws Exception {
         mockMvc.perform(get("/employees/list")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isOk())
@@ -75,14 +75,14 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenNotAllowedEmployeeListingEmployees_thenForbidden() throws Exception {
+    void whenNotAllowedEmployeeListingEmployeesThenForbidden() throws Exception {
         mockMvc.perform(get("/employees/list")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAnonymousCreateEmployee_thenForbidden() throws Exception {
+    void whenAnonymousCreateEmployeeThenForbidden() throws Exception {
         EmployeeRegisterDTO employeeDTO = new EmployeeRegisterDTO(
                 "John",
                 "Doe",
@@ -99,7 +99,7 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAllowedEmployeeCreateEmployee_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeCreateEmployeeThenSucceeds() throws Exception {
         EmployeeRegisterDTO employeeDTO = new EmployeeRegisterDTO(
                 "John",
                 "Doe",
@@ -122,7 +122,7 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenNotAllowedEmployeeCreateEmployee_thenForbidden() throws Exception {
+    void whenNotAllowedEmployeeCreateEmployeeThenForbidden() throws Exception {
         EmployeeRegisterDTO employeeDTO = new EmployeeRegisterDTO(
                 "John",
                 "Doe",
@@ -140,7 +140,7 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAnonymousUpdateEmployee_thenForbidden() throws Exception {
+    void whenAnonymousUpdateEmployeeThenForbidden() throws Exception {
         EmployeeRegisterDTO employeeDTO = new EmployeeRegisterDTO(
                 "Updated",
                 "Name",
@@ -157,7 +157,7 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAllowedEmployeeUpdateEmployee_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeUpdateEmployeeThenSucceeds() throws Exception {
         Employee existingEmployee = employeeService.getEmployeeByEmail("manager@manager.com");
 
         EmployeeRegisterDTO employeeDTO = new EmployeeRegisterDTO(
@@ -183,7 +183,7 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAllowedEmployeeUpdateEmployeeWithExistingEmail_thenConflict() throws Exception {
+    void whenAllowedEmployeeUpdateEmployeeWithExistingEmailThenConflict() throws Exception {
         EmployeeRegisterDTO newEmployeeDTO = new EmployeeRegisterDTO(
                 "New",
                 "Employee",
@@ -218,7 +218,7 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenNotAllowedEmployeeUpdateEmployee_thenForbidden() throws Exception {
+    void whenNotAllowedEmployeeUpdateEmployeeThenForbidden() throws Exception {
         EmployeeRegisterDTO employeeDTO = new EmployeeRegisterDTO(
                 "Updated",
                 "Name",
@@ -236,13 +236,13 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAnonymousDeleteEmployee_thenForbidden() throws Exception {
+    void whenAnonymousDeleteEmployeeThenForbidden() throws Exception {
         mockMvc.perform(delete("/employees/1"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeDeleteEmployee_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeDeleteEmployeeThenSucceeds() throws Exception {
         Employee employeeToDelete = employeeService.getEmployeeByEmail("financial@financial.com");
 
         assertTrue(employeeToDelete.isActive());
@@ -260,14 +260,14 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenNotAllowedEmployeeDeleteEmployee_thenForbidden() throws Exception {
+    void whenNotAllowedEmployeeDeleteEmployeeThenForbidden() throws Exception {
         mockMvc.perform(delete("/employees/delete/1")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeUpdateNonExistentEmployee_thenNotFound() throws Exception {
+    void whenAllowedEmployeeUpdateNonExistentEmployeeThenNotFound() throws Exception {
         EmployeeRegisterDTO employeeDTO = new EmployeeRegisterDTO(
                 "Updated",
                 "Name",
@@ -285,20 +285,20 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAllowedEmployeeDeleteNonExistentEmployee_thenNotFound() throws Exception {
+    void whenAllowedEmployeeDeleteNonExistentEmployeeThenNotFound() throws Exception {
         mockMvc.perform(delete("/employees/delete/999999")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNotFound());
     }
 
     @Test
-    void whenAnonymousActivateEmployee_thenForbidden() throws Exception {
+    void whenAnonymousActivateEmployeeThenForbidden() throws Exception {
         mockMvc.perform(put("/employees/activate/1"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeActivateEmployee_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeActivateEmployeeThenSucceeds() throws Exception {
         Employee employeeToActivate = employeeService.getEmployeeByEmail("financial2@financial.com");
 
         assertFalse(employeeToActivate.isActive());
@@ -316,21 +316,21 @@ public class EmployeeControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenNotAllowedEmployeeActivateEmployee_thenForbidden() throws Exception {
+    void whenNotAllowedEmployeeActivateEmployeeThenForbidden() throws Exception {
         mockMvc.perform(put("/employees/activate/1")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeActivateNonExistentEmployee_thenNotFound() throws Exception {
+    void whenAllowedEmployeeActivateNonExistentEmployeeThenNotFound() throws Exception {
         mockMvc.perform(put("/employees/activate/999999") // non-existent ID
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNotFound());
     }
 
     @Test
-    void whenAllowedEmployeeActivateAlreadyActiveEmployee_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeActivateAlreadyActiveEmployeeThenSucceeds() throws Exception {
         EmployeeRegisterDTO newEmployeeDTO = new EmployeeRegisterDTO(
                 "Already",
                 "Active",

--- a/src/test/java/example/medCashFlow/InstallmentControllerTests.java
+++ b/src/test/java/example/medCashFlow/InstallmentControllerTests.java
@@ -18,13 +18,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class InstallmentControllerTests extends MedCashFlowApplicationTests {
 
     @Test
-    void whenAnonymousUpdateInstallment_thenForbidden() throws Exception {
+    void whenAnonymousUpdateInstallmentThenForbidden() throws Exception {
         mockMvc.perform(put("/installments//update/1"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeUpdateInstallment_thenNoContent() throws Exception {
+    void whenAllowedEmployeeUpdateInstallmentThenNoContent() throws Exception {
         InstallmentUpdateDTO installmentUpdateDTO = new InstallmentUpdateDTO(LocalDateTime.now().plusDays(7));
 
         mockMvc.perform(put("/installments/update/1")
@@ -35,40 +35,40 @@ public class InstallmentControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAdminUpdateInstallment_thenForbidden() throws Exception {
+    void whenAdminUpdateInstallmentThenForbidden() throws Exception {
         mockMvc.perform(put("/installments/update/1")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAnonymousMarksInstallmentAsPaid_thenForbidden() throws Exception {
+    void whenAnonymousMarksInstallmentAsPaidThenForbidden() throws Exception {
         mockMvc.perform(put("/installments/mark-as-paid/1"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeMarksInstallmentAsPaid_thenNoContent() throws Exception {
+    void whenAllowedEmployeeMarksInstallmentAsPaidThenNoContent() throws Exception {
         mockMvc.perform(put("/installments/mark-as-paid/1")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNoContent());
     }
 
     @Test
-    void whenAdminMarksInstallmentAsPaid_thenForbidden() throws Exception {
+    void whenAdminMarksInstallmentAsPaidThenForbidden() throws Exception {
         mockMvc.perform(put("/installments/mark-as-paid/1")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAnonymousMarkInstallmentAsUnpaid_thenForbidden() throws Exception {
+    void whenAnonymousMarkInstallmentAsUnpaidThenForbidden() throws Exception {
         mockMvc.perform(put("/installments/mark-as-unpaid/1"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeMarkInstallmentAsUnpaid_thenNoContent() throws Exception {
+    void whenAllowedEmployeeMarkInstallmentAsUnpaidThenNoContent() throws Exception {
         mockMvc.perform(put("/installments/mark-as-paid/1")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNoContent());
@@ -79,7 +79,7 @@ public class InstallmentControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAdminMarkInstallmentAsUnpaid_thenForbidden() throws Exception {
+    void whenAdminMarkInstallmentAsUnpaidThenForbidden() throws Exception {
         mockMvc.perform(put("/installments/mark-as-unpaid/1")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());

--- a/src/test/java/example/medCashFlow/InvolvedControllerTests.java
+++ b/src/test/java/example/medCashFlow/InvolvedControllerTests.java
@@ -21,13 +21,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class InvolvedControllerTests extends MedCashFlowApplicationTests {
 
     @Test
-    void whenAnonymousGetInvolvedById_thenForbidden() throws Exception {
+    void whenAnonymousGetInvolvedByIdThenForbidden() throws Exception {
         mockMvc.perform(get("/involveds/1"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeGetInvolvedById_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeGetInvolvedByIdThenSucceeds() throws Exception {
         mockMvc.perform(get("/involveds/1")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isOk())
@@ -40,27 +40,27 @@ class InvolvedControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAllowedEmployeeGetNonExistentInvolvedById_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeGetNonExistentInvolvedByIdThenSucceeds() throws Exception {
         mockMvc.perform(get("/involveds/999")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNotFound());
     }
 
     @Test
-    void whenAdminGetInvolvedById_thenForbidden() throws Exception {
+    void whenAdminGetInvolvedByIdThenForbidden() throws Exception {
         mockMvc.perform(get("/involveds/1")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAnonymousListInvolveds_thenForbidden() throws Exception {
+    void whenAnonymousListInvolvedsThenForbidden() throws Exception {
         mockMvc.perform(get("/involveds/list"))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeListInvolveds_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeListInvolvedsThenSucceeds() throws Exception {
         mockMvc.perform(get("/involveds/list")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isOk())
@@ -74,14 +74,14 @@ class InvolvedControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAdminListInvolveds_thenForbidden() throws Exception {
+    void whenAdminListInvolvedsThenForbidden() throws Exception {
         mockMvc.perform(get("/involveds/list")
                         .header("Authorization", "Bearer " + adminToken))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void whenAllowedEmployeeCreateInvolved_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeCreateInvolvedThenSucceeds() throws Exception {
         InvolvedRegisterDTO involvedDTO = new InvolvedRegisterDTO(
                 "Test Involved",
                 "12345678901",
@@ -103,7 +103,7 @@ class InvolvedControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenCreateInvolvedWithExistingDocument_thenConflict() throws Exception {
+    void whenCreateInvolvedWithExistingDocumentThenConflict() throws Exception {
         InvolvedRegisterDTO firstInvolved = new InvolvedRegisterDTO(
                 "First Involved",
                 "12345678903",
@@ -132,7 +132,7 @@ class InvolvedControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAllowedEmployeeUpdateInvolved_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeUpdateInvolvedThenSucceeds() throws Exception {
         InvolvedRegisterDTO updateDTO = new InvolvedRegisterDTO(
                 "Updated Name",
                 "12345678904",
@@ -154,7 +154,7 @@ class InvolvedControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenUpdateNonExistentInvolved_thenNotFound() throws Exception {
+    void whenUpdateNonExistentInvolvedThenNotFound() throws Exception {
         InvolvedRegisterDTO updateDTO = new InvolvedRegisterDTO(
                 "Non Existent",
                 "12345678909",
@@ -170,7 +170,7 @@ class InvolvedControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenAllowedEmployeeDeleteAnActivateInvolved_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeDeleteAnActivateInvolvedThenSucceeds() throws Exception {
         mockMvc.perform(delete("/involveds/1")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNoContent());
@@ -182,14 +182,14 @@ class InvolvedControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenDeleteNonExistentInvolved_thenNotFound() throws Exception {
+    void whenDeleteNonExistentInvolvedThenNotFound() throws Exception {
         mockMvc.perform(delete("/involveds/999999")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNotFound());
     }
 
     @Test
-    void whenAllowedEmployeeActivateInvolved_thenSucceeds() throws Exception {
+    void whenAllowedEmployeeActivateInvolvedThenSucceeds() throws Exception {
         InvolvedRegisterDTO createDTO = new InvolvedRegisterDTO(
                 "To Activate",
                 "12345678906",
@@ -217,7 +217,7 @@ class InvolvedControllerTests extends MedCashFlowApplicationTests {
     }
 
     @Test
-    void whenActivateNonExistentInvolved_thenNotFound() throws Exception {
+    void whenActivateNonExistentInvolvedThenNotFound() throws Exception {
         mockMvc.perform(put("/involveds/activate/999999")
                         .header("Authorization", "Bearer " + managerToken))
                 .andExpect(status().isNotFound());


### PR DESCRIPTION
- **Fix: snake_case to camelCase on test classes**
- **Fix: snake_case to camelCase on employee classes and DTOs**

The main changes were on the test classes, every method was named mixing
camelCase with snake_case and on the employee model, which had two variables,
'first_name' and 'last_name', and the manager DTO.
