### PR TITLE
G-CLI Critical Issues (2.5 Pro)

### DIFF
--- a/src/main/java/example/medCashFlow/repository/InstallmentRepository.java
+++ b/src/main/java/example/medCashFlow/repository/InstallmentRepository.java
@@ -2,7 +2,6 @@ package example.medCashFlow.repository;
 
 import example.medCashFlow.model.Installment;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,8 +10,4 @@ import java.util.List;
 public interface InstallmentRepository extends JpaRepository<Installment, Long> {
 
     List<Installment> findAllByBillId(Long billId);
-
-    @Query("SELECT COALESCE(MAX(id), 0) + 1 FROM installments")
-    Long getNextId();
 }
-

--- a/src/main/java/example/medCashFlow/services/AccountPlanningService.java
+++ b/src/main/java/example/medCashFlow/services/AccountPlanningService.java
@@ -9,12 +9,14 @@ import example.medCashFlow.model.Clinic;
 import example.medCashFlow.repository.AccountPlanningRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class AccountPlanningService {
 
     private final AccountPlanningRepository repository;

--- a/src/main/java/example/medCashFlow/services/BillService.java
+++ b/src/main/java/example/medCashFlow/services/BillService.java
@@ -10,12 +10,14 @@ import example.medCashFlow.repository.BillRepository;
 import lombok.RequiredArgsConstructor;
 import example.medCashFlow.mappers.BillMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class BillService {
 
     private final InstallmentService installmentService;

--- a/src/main/java/example/medCashFlow/services/ClinicService.java
+++ b/src/main/java/example/medCashFlow/services/ClinicService.java
@@ -10,12 +10,14 @@ import example.medCashFlow.model.Clinic;
 import example.medCashFlow.repository.ClinicRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ClinicService {
 
     private final ClinicRepository repository;

--- a/src/main/java/example/medCashFlow/services/EmployeeService.java
+++ b/src/main/java/example/medCashFlow/services/EmployeeService.java
@@ -12,12 +12,14 @@ import example.medCashFlow.repository.EmployeeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class EmployeeService {
 
     private final EmployeeRepository repository;

--- a/src/main/java/example/medCashFlow/services/InstallmentService.java
+++ b/src/main/java/example/medCashFlow/services/InstallmentService.java
@@ -7,6 +7,7 @@ import example.medCashFlow.model.Installment;
 import example.medCashFlow.repository.InstallmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -14,6 +15,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class InstallmentService {
 
     private final InstallmentRepository repository;
@@ -30,7 +32,6 @@ public class InstallmentService {
         List<Installment> installmentList = new ArrayList<>();
         for (int i = 0; i < installmentAmount; i++) {
             Installment installment = new Installment();
-            installment.setId(repository.getNextId() + i);
             installment.setBill(bill);
             installment.setInstallmentNumber(installmentAmount);
             installment.setPricing(installmentPrice);
@@ -47,32 +48,24 @@ public class InstallmentService {
 
     public void updateInstallmentById(Long id, InstallmentUpdateDTO data) {
         Installment installment = getInstallmentById(id);
-
         installment.setDueDate(data.dueDate());
-
         repository.save(installment);
     }
 
     public void markInstallmentAsPaid(Long id) {
         Installment installment = getInstallmentById(id);
-
         installment.setPaid(true);
-
         repository.save(installment);
     }
 
     public void deleteInstallmentByBillId(Long id) {
         List<Installment> installments = getAllInstallmentsByBillId(id);
-
         repository.deleteAll(installments);
     }
 
-
     public void markInstallmentAsUnpaid(Long id) {
         Installment installment = getInstallmentById(id);
-
         installment.setPaid(false);
-
         repository.save(installment);
     }
 

--- a/src/main/java/example/medCashFlow/services/InvolvedService.java
+++ b/src/main/java/example/medCashFlow/services/InvolvedService.java
@@ -10,12 +10,14 @@ import example.medCashFlow.model.Involved;
 import example.medCashFlow.repository.InvolvedRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class InvolvedService {
 
     private final InvolvedRepository repository;
@@ -97,4 +99,3 @@ public class InvolvedService {
     }
 
 }
-


### PR DESCRIPTION
- Add @Transactional to all service classes to ensure data consistency
- Remove manual ID generation in InstallmentService that could cause race conditions
- Remove getNextId() method from InstallmentRepository
- Let JPA handle ID generation with @GeneratedValue strategy

This fixes critical issues:
1. Data inconsistency when multiple operations fail mid-transaction
2. Race conditions and ID conflicts in concurrent environments
3. Potential orphaned records when operations fail